### PR TITLE
Replacing the integer division operator with a rounding function

### DIFF
--- a/Resources/Scripts/Scene/3/scene3_group133002259.lua
+++ b/Resources/Scripts/Scene/3/scene3_group133002259.lua
@@ -970,7 +970,7 @@ function L1_1(A0_2, A1_2)
   L3_2 = A0_2
   L4_2 = "auth_uid_p1"
   L5_2 = A0_2.uid
-  L5_2 = L5_2 // 10000
+  L5_2 = math.floor(L5_2 / 10000)
   L2_2(L3_2, L4_2, L5_2)
   L2_2 = ScriptLib
   L2_2 = L2_2.SetGroupVariableValue

--- a/Resources/Scripts/Scene/3/scene3_group133008163.lua
+++ b/Resources/Scripts/Scene/3/scene3_group133008163.lua
@@ -625,7 +625,7 @@ function L2_1(A0_2, A1_2)
         L10_2 = 10
         L11_2 = L5_2 - 1
         L9_2 = L9_2(L10_2, L11_2)
-        L8_2 = L8_2 // L9_2
+        L8_2 = math.floor(L8_2 / L9_2)
         if L8_2 ~= 1 then
           L8_2 = math
           L8_2 = L8_2.pow
@@ -672,7 +672,7 @@ function L2_1(A0_2, A1_2)
         L10_2 = 10
         L11_2 = L5_2 - 1
         L9_2 = L9_2(L10_2, L11_2)
-        L8_2 = L8_2 // L9_2
+        L8_2 = math.floor(L8_2 / L9_2)
         if L8_2 ~= 1 then
           L8_2 = math
           L8_2 = L8_2.pow

--- a/Resources/Scripts/Scene/3/scene3_group133102769.lua
+++ b/Resources/Scripts/Scene/3/scene3_group133102769.lua
@@ -1301,7 +1301,7 @@ function L4_1(A0_2, A1_2)
   L3_2 = A0_2
   L4_2 = "auth_uid_p1"
   L5_2 = A0_2.uid
-  L5_2 = L5_2 // 10000
+  L5_2 = math.floor(L5_2 / 10000)
   L2_2(L3_2, L4_2, L5_2)
   L2_2 = ScriptLib
   L2_2 = L2_2.SetGroupVariableValue


### PR DESCRIPTION
Replacing the "//" operator with the "math.floor()" function to avoid Grasscutter loading Lua with an error: 'javax.script.ScriptException: eval threw javax.script.ScriptException: eval threw javax.script.ScriptException: [string "script"]:1304: unexpected symbol 47 (/)'